### PR TITLE
Customize breadcrumb serialization

### DIFF
--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -42,8 +42,12 @@ class Breadcrumb implements Arrayable
         return $this->data;
     }
 
-    public function toArray()
+    public function toArray(): array
     {
+        if (InertiaBreadcrumbs::$serializeUsingCallback) {
+            return call_user_func(InertiaBreadcrumbs::$serializeUsingCallback, $this);
+        }
+
         return array_filter([
             'title' => $this->title(),
             'url' => $this->url(),

--- a/src/InertiaBreadcrumbs.php
+++ b/src/InertiaBreadcrumbs.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace RobertBoes\InertiaBreadcrumbs;
+
+class InertiaBreadcrumbs
+{
+    /**
+     * The callback that is responsible serializing breadcrumbs to the frontend
+     *
+     * @var callable|null
+     */
+    public static $serializeUsingCallback;
+
+    public static function serializeUsing(callable $callback)
+    {
+        static::$serializeUsingCallback = $callback;
+    }
+}

--- a/src/InertiaBreadcrumbsServiceProvider.php
+++ b/src/InertiaBreadcrumbsServiceProvider.php
@@ -14,11 +14,6 @@ class InertiaBreadcrumbsServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
     {
-        /*
-         * This class is a Package Service Provider
-         *
-         * More info: https://github.com/spatie/laravel-package-tools
-         */
         $package
             ->name('inertia-breadcrumbs')
             ->hasConfigFile();

--- a/tests/SerializationTest.php
+++ b/tests/SerializationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace RobertBoes\InertiaBreadcrumbs\Tests;
+
+use Inertia\Inertia;
+use Diglactic\Breadcrumbs\Breadcrumbs;
+use Diglactic\Breadcrumbs\Generator as BreadcrumbTrail;
+use Inertia\Testing\AssertableInertia as Assert;
+use RobertBoes\InertiaBreadcrumbs\Breadcrumb;
+use RobertBoes\InertiaBreadcrumbs\InertiaBreadcrumbs;
+use RobertBoes\InertiaBreadcrumbs\Middleware;
+
+class SerializationTest extends TestCase
+{
+    /**
+     * @param \Illuminate\Routing\Router $router
+     */
+    public function defineRoutes($router): void
+    {
+        $router->get('/home', function () {
+            return Inertia::render('Home', []);
+        })->name('home')->middleware([Middleware::class]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_serializes_breadcrumbs(): void
+    {
+        Breadcrumbs::for('home', function (BreadcrumbTrail $trail) {
+            $trail->push('Home', route('home'));
+        });
+
+        $this->getJson('/home')
+            ->assertOk()
+            ->assertInertia(
+                fn (Assert $page) => $page
+                    ->component('Home')
+                    ->has(
+                        'breadcrumbs',
+                        1,
+                        fn (Assert $page) => $page
+                            ->where('title', 'Home')
+                            ->where('url', route('home'))
+                            ->where('current', true)
+                            ->missing('data')
+                    )
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_use_a_custom_serializer(): void
+    {
+        Breadcrumbs::for('home', function (BreadcrumbTrail $trail) {
+            $trail->push('Home', route('home'));
+        });
+
+        InertiaBreadcrumbs::serializeUsing(fn (Breadcrumb $breadcrumb) => [
+            'name' => $breadcrumb->title(),
+            'href' => $breadcrumb->url(),
+            'active' => $breadcrumb->current(),
+            'data' => $breadcrumb->data(),
+        ]);
+
+        $this->getJson('/home')
+            ->assertOk()
+            ->assertInertia(
+                fn (Assert $page) => $page
+                    ->component('Home')
+                    ->has(
+                        'breadcrumbs',
+                        1,
+                        fn (Assert $page) => $page
+                            ->where('name', 'Home')
+                            ->where('href', route('home'))
+                            ->where('active', true)
+                            ->where('data', [])
+                    )
+            );
+    }
+}

--- a/tests/SerializationTest.php
+++ b/tests/SerializationTest.php
@@ -2,9 +2,9 @@
 
 namespace RobertBoes\InertiaBreadcrumbs\Tests;
 
-use Inertia\Inertia;
 use Diglactic\Breadcrumbs\Breadcrumbs;
 use Diglactic\Breadcrumbs\Generator as BreadcrumbTrail;
+use Inertia\Inertia;
 use Inertia\Testing\AssertableInertia as Assert;
 use RobertBoes\InertiaBreadcrumbs\Breadcrumb;
 use RobertBoes\InertiaBreadcrumbs\InertiaBreadcrumbs;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\View;
 use Inertia\ServiceProvider as InertiaServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
+use RobertBoes\InertiaBreadcrumbs\InertiaBreadcrumbs;
 use RobertBoes\InertiaBreadcrumbs\InertiaBreadcrumbsServiceProvider;
 
 class TestCase extends Orchestra
@@ -13,6 +14,8 @@ class TestCase extends Orchestra
     protected function setUp(): void
     {
         parent::setUp();
+
+        InertiaBreadcrumbs::$serializeUsingCallback = null;
 
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'RobertBoes\\InertiaBreadcrumbs\\Database\\Factories\\'.class_basename($modelName).'Factory'


### PR DESCRIPTION
Adds the ability to customize how breadcrumbs are serialized. This can be configured in a service providers, like this:

```php
<?php

namespace App\Providers;

use RobertBoes\InertiaBreadcrumbs\InertiaBreadcrumbs;

class AppServiceProvider extends ServiceProvider
{
	public function boot(): void
    {
        InertiaBreadcrumbs::serializeUsing(fn (Breadcrumb $breadcrumb) => [
            'name' => $breadcrumb->title(),
            'href' => $breadcrumb->url(),
            'active' => $breadcrumb->current(),
            'data' => $breadcrumb->data(),
        ]);
    }
}
```