### PR TITLE
Added the option to ignore the request query string when determining the current URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ class AppServiceProvider extends ServiceProvider
 }
 ```
 
-## Ignoring the query string when determining the current URL
+## Including the query string when determining the current URL
 
-By default, the full request URL will be used to check for the current url, meaning a breadcrumb defined for `/users/{id}` will match `/users/1`, but not `/users/1?foo=bar`. To change this behaviour and completely ignore the query string, change `ignore_query` to `true` in the `config/inertia-breadcrumbs.php` file.
+By default, the query string will be ignored when determining the current url, meaning a breadcrumb defined for `/users/{id}` will match both `/users/1` and `/users/1?foo=bar`. To change this behaviour and include the query string (meaning `/users/1?foo=bar` will not be seen as the current page), change `ignore_query` to `false` in the `config/inertia-breadcrumbs.php` file.
 
 ### Notes on using `glhd/gretel`
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ return [
 composer test
 ```
 
+## Upgrading
+
+For notable changes see [UPGRADING](UPGRADING.md).
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ class AppServiceProvider extends ServiceProvider
 }
 ```
 
+## Ignoring the query string when determining the current URL
+
+By default, the full request URL will be used to check for the current url, meaning a breadcrumb defined for `/users/{id}` will match `/users/1`, but not `/users/1?foo=bar`. To change this behaviour and completely ignore the query string, change `ignore_query` to `true` in the `config/inertia-breadcrumbs.php` file.
+
 ### Notes on using `glhd/gretel`
 
 `glhd/gretel` shares the breadcrumbs automatically if it detects Inertia is installed and shares the props with the same key (`breadcrumbs`). If you want to use this package with gretel you should disable their automatic sharing by updating the config:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,27 @@
+# Upgrading
+
+This document outlines breaking changes introduced in 0.x versions and major releases.
+
+We accept PRs to improve this guide.
+
+## From 0.3.x to 0.4.x
+
+### Query string is now ignored when determining the current URL (#9)
+
+In version <0.3.x an active breadcrumb was determined by the full URL.
+This meant that a route such as `/users/{id}` would not set the active breadcrumb when a user visits `/users/1?foo=bar`.
+The default behaviour has been changed to ignore the query string.
+
+The config file has been updated to disable this behaviour:
+```diff
+return [
+    // ...
+
++    /**
++     * Whether the query string should be ignored when determining the current route
++     */
++    'ignore_query' => true,
+];
+```
+
+If your app relies on the previous behaviour (not ignoring the query string) you can set the `inertia-breadcrumbs.ignore_query` config value to `false`.

--- a/config/inertia-breadcrumbs.php
+++ b/config/inertia-breadcrumbs.php
@@ -33,4 +33,9 @@ return [
      */
     'classifier' => AppendAllBreadcrumbs::class,
     // 'classifier' => IgnoreSingleBreadcrumbs::class,
+
+    /**
+     * Whether the query string should be ignored when determining the current route
+     */
+    'ignore_query' => false,
 ];

--- a/config/inertia-breadcrumbs.php
+++ b/config/inertia-breadcrumbs.php
@@ -37,5 +37,5 @@ return [
     /**
      * Whether the query string should be ignored when determining the current route
      */
-    'ignore_query' => false,
+    'ignore_query' => true,
 ];

--- a/src/Collectors/AbstractBreadcrumbCollector.php
+++ b/src/Collectors/AbstractBreadcrumbCollector.php
@@ -16,7 +16,7 @@ abstract class AbstractBreadcrumbCollector implements BreadcrumbCollectorContrac
 
     protected function isCurrentUrl(Request $request, string $url): bool
     {
-        if (config('inertia-breadcrumbs.ignore_query')) {
+        if (config('inertia-breadcrumbs.ignore_query', true)) {
             return $request->url() === $url;
         }
 

--- a/src/Collectors/AbstractBreadcrumbCollector.php
+++ b/src/Collectors/AbstractBreadcrumbCollector.php
@@ -2,6 +2,7 @@
 
 namespace RobertBoes\InertiaBreadcrumbs\Collectors;
 
+use Illuminate\Http\Request;
 use RobertBoes\InertiaBreadcrumbs\Exceptions\PackageNotInstalledException;
 
 abstract class AbstractBreadcrumbCollector implements BreadcrumbCollectorContract
@@ -11,6 +12,15 @@ abstract class AbstractBreadcrumbCollector implements BreadcrumbCollectorContrac
         if (! $this->canUseImplementation()) {
             throw new PackageNotInstalledException(static::packageIdentifier());
         }
+    }
+
+    protected function isCurrentUrl(Request $request, string $url): bool
+    {
+        if (config('inertia-breadcrumbs.ignore_query')) {
+            return $request->url() === $url;
+        }
+
+        return $request->fullUrlIs($url);
     }
 
     private function canUseImplementation(): bool

--- a/src/Collectors/DiglacticBreadcrumbsCollector.php
+++ b/src/Collectors/DiglacticBreadcrumbsCollector.php
@@ -23,7 +23,7 @@ class DiglacticBreadcrumbsCollector extends AbstractBreadcrumbCollector
 
             return new Breadcrumb(
                 title: $breadcrumb->title,
-                current: $request->fullUrlIs($breadcrumb->url),
+                current: $this->isCurrentUrl($request, $breadcrumb->url),
                 url: $breadcrumb->url,
                 data: $data,
             );

--- a/src/Collectors/GretelBreadcrumbsCollector.php
+++ b/src/Collectors/GretelBreadcrumbsCollector.php
@@ -17,10 +17,10 @@ class GretelBreadcrumbsCollector extends AbstractBreadcrumbCollector
     {
         $breadcrumbs = $this->getBreadcrumbs($request);
 
-        return new BreadcrumbCollection($breadcrumbs, function (GretelBreadcrumb $breadcrumb): Breadcrumb {
+        return new BreadcrumbCollection($breadcrumbs, function (GretelBreadcrumb $breadcrumb) use ($request): Breadcrumb {
             return new Breadcrumb(
                 title: $breadcrumb->title,
-                current: $breadcrumb->is_current_page,
+                current: $this->isCurrentUrl($request, $breadcrumb->url),
                 url: $breadcrumb->url,
             );
         });

--- a/src/Collectors/TabunaBreadcrumbsCollector.php
+++ b/src/Collectors/TabunaBreadcrumbsCollector.php
@@ -19,7 +19,7 @@ class TabunaBreadcrumbsCollector extends AbstractBreadcrumbCollector
         return new BreadcrumbCollection($breadcrumbs, function (Crumb $breadcrumb) use ($request): Breadcrumb {
             return new Breadcrumb(
                 title: $breadcrumb->title(),
-                current: $request->fullUrlIs($breadcrumb->url()),
+                current: $this->isCurrentUrl($request, $breadcrumb->url()),
                 url: $breadcrumb->url(),
             );
         });

--- a/tests/DiglacticCollectorTest.php
+++ b/tests/DiglacticCollectorTest.php
@@ -184,36 +184,8 @@ class DiglacticCollectorTest extends TestCase
      * @test
      * @define-env usesCustomMiddlewareGroup
      */
-    public function it_does_not_ignore_query_parameters_by_default_when_determining_current_route()
+    public function it_ignores_the_query_string_by_default_when_determining_current_route()
     {
-        $user = User::factory()->create();
-        DiglacticBreadcrumbs::for('users.show', function (DiglacticTrail $trail, User $user) {
-            $trail->push($user->name, route('users.show', ['user' => $user]));
-        });
-
-        $this->getJson(route('users.show', ['user' => $user, 'foo' => 'bar']))
-            ->assertOk()
-            ->assertInertia(
-                fn (Assert $page) => $page
-                    ->component('Users/Show')
-                    ->has(
-                        'breadcrumbs',
-                        1,
-                        fn (Assert $prop) => $prop
-                            ->missing('current')
-                            ->etc()
-                    )
-            );
-    }
-
-    /**
-     * @test
-     * @define-env usesCustomMiddlewareGroup
-     */
-    public function it_ignores_query_parameters_when_configured_to_do_so_when_determining_current_route()
-    {
-        Config::set('inertia-breadcrumbs.ignore_query', true);
-
         $user = User::factory()->create();
         DiglacticBreadcrumbs::for('users.show', function (DiglacticTrail $trail, User $user) {
             $trail->push($user->name, route('users.show', ['user' => $user]));
@@ -229,6 +201,34 @@ class DiglacticCollectorTest extends TestCase
                         1,
                         fn (Assert $prop) => $prop
                             ->where('current', true)
+                            ->etc()
+                    )
+            );
+    }
+
+    /**
+     * @test
+     * @define-env usesCustomMiddlewareGroup
+     */
+    public function it_does_not_ignore_query_parameters_when_configured_to_do_so_when_determining_current_route()
+    {
+        Config::set('inertia-breadcrumbs.ignore_query', false);
+
+        $user = User::factory()->create();
+        DiglacticBreadcrumbs::for('users.show', function (DiglacticTrail $trail, User $user) {
+            $trail->push($user->name, route('users.show', ['user' => $user]));
+        });
+
+        $this->getJson(route('users.show', ['user' => $user, 'foo' => 'bar']))
+            ->assertOk()
+            ->assertInertia(
+                fn (Assert $page) => $page
+                    ->component('Users/Show')
+                    ->has(
+                        'breadcrumbs',
+                        1,
+                        fn (Assert $prop) => $prop
+                            ->missing('current')
                             ->etc()
                     )
             );

--- a/tests/TabunaCollectorTest.php
+++ b/tests/TabunaCollectorTest.php
@@ -140,37 +140,8 @@ class TabunaCollectorTest extends TestCase
      * @test
      * @define-env usesCustomMiddlewareGroup
      */
-    public function it_does_not_ignore_query_parameters_by_default_when_determining_current_route()
+    public function it_ignores_the_query_string_by_default_when_determining_current_route()
     {
-        TabunaBreadcrumbs::for('profile.edit', function (TabunaTrail $trail) {
-            $trail->push('Profile', route('profile'));
-            $trail->push('Edit profile', route('profile.edit'));
-        });
-
-        $request = RequestBuilder::create('profile.edit', ['foo' => 'bar']);
-        $crumbs = app(BreadcrumbCollectorContract::class)->forRequest($request);
-
-        $this->assertSame(2, $crumbs->items()->count());
-        $this->assertSame([
-            [
-                'title' => 'Profile',
-                'url' => route('profile'),
-            ],
-            [
-                'title' => 'Edit profile',
-                'url' => route('profile.edit'),
-            ],
-        ], $crumbs->toArray());
-    }
-
-    /**
-     * @test
-     * @define-env usesCustomMiddlewareGroup
-     */
-    public function it_ignores_query_parameters_when_configured_to_do_so_when_determining_current_route()
-    {
-        Config::set('inertia-breadcrumbs.ignore_query', true);
-
         TabunaBreadcrumbs::for('profile.edit', function (TabunaTrail $trail) {
             $trail->push('Profile', route('profile'));
             $trail->push('Edit profile', route('profile.edit'));
@@ -189,6 +160,35 @@ class TabunaCollectorTest extends TestCase
                 'title' => 'Edit profile',
                 'url' => route('profile.edit'),
                 'current' => true,
+            ],
+        ], $crumbs->toArray());
+    }
+
+    /**
+     * @test
+     * @define-env usesCustomMiddlewareGroup
+     */
+    public function it_does_not_ignore_query_parameters_when_configured_to_do_so_when_determining_current_route()
+    {
+        Config::set('inertia-breadcrumbs.ignore_query', false);
+
+        TabunaBreadcrumbs::for('profile.edit', function (TabunaTrail $trail) {
+            $trail->push('Profile', route('profile'));
+            $trail->push('Edit profile', route('profile.edit'));
+        });
+
+        $request = RequestBuilder::create('profile.edit', ['foo' => 'bar']);
+        $crumbs = app(BreadcrumbCollectorContract::class)->forRequest($request);
+
+        $this->assertSame(2, $crumbs->items()->count());
+        $this->assertSame([
+            [
+                'title' => 'Profile',
+                'url' => route('profile'),
+            ],
+            [
+                'title' => 'Edit profile',
+                'url' => route('profile.edit'),
             ],
         ], $crumbs->toArray());
     }


### PR DESCRIPTION
When using this package, I noticed the current URL/breadcrumb would be incorrectly determined when the URL included a query string. A breadcrumb configured for `/users/{id}` would be correctly marked as current for `/users/1`, but not for `/users/1?foo=bar`. This PR aims to fix this in `DiglacticBreadcrumbsCollector` and `TabunaCollectorTest`. I've not touched `GretelBreadcrumbsCollector` as it seemed to already have its own logic to determine the current page.