### PR TITLE
Support `null` breadcrumb URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,16 @@ No matter which third party package you're using, this package will always share
 ```json
 [
     {
-        title: "Dashboard",
-        url: "http://localhost/dashboard"
+        "title": "Dashboard",
+        "url": "http://localhost/dashboard"
     },
     {
-        title: "Profile",
-        url: "http://localhost/dashboard/profile",
-        current: true
+        "title": "Profile",
+        "url": "http://localhost/dashboard/profile",
+        "current": true
     },
     {
-        title: "Breadcrumb without URL"
+        "title": "Breadcrumb without URL"
     }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -63,15 +63,20 @@ No matter which third party package you're using, this package will always share
 [
     {
         title: "Dashboard",
-        url: "http://localhost/dashboard",
+        url: "http://localhost/dashboard"
     },
     {
         title: "Profile",
         url: "http://localhost/dashboard/profile",
-        current: true,
+        current: true
+    },
+    {
+        title: "Breadcrumb without URL"
     }
 ]
 ```
+
+Note that due to package differences, URLs are always present when using `glhd/gretel`, but are otherwise optional.  
 
 An example to render your breadcrumbs in Vue 3 could look like the following:
 
@@ -81,12 +86,13 @@ An example to render your breadcrumbs in Vue 3 could look like the following:
         <ol>
             <li v-for="page in breadcrumbs">
                 <div>
-                    <span v-if="page ==='/'">/</span>
+                    <span v-if="page === '/'">/</span>
                     <a
-                        v-else
+                        v-else-if="page.url"
                         :href="page.url"
                         :class="{ 'border-b border-blue-400': page.current }"
                     >{{ page.title }}</a>
+                    <span v-else>{{ page.title }}</span>
                 </div>
             </li>
         </ol>

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,24 @@ This document outlines breaking changes introduced in 0.x versions and major rel
 
 We accept PRs to improve this guide.
 
+## From 0.4.x to 0.5.x
+
+`null` breadcrumb URLs are now supported for `diglactic/laravel-breadcrumbs` and `tabuna/breadcrumbs` collectors. 
+Previously, defining a `null` URL would've thrown an exception, so this is technically a backwards-compatible change.
+However, this changes the array shape of outputted breadcrumbs, and you may want to update frontend components to match.
+Here's an example TypeScript type to illustrate:
+
+```diff
+type Breadcrumb {
+    title: string;
+-   url: string;
++   url?: string;
+    current?: boolean;
+};
+
+type Breadcrumbs = Breadcrumb[];
+```
+
 ## From 0.3.x to 0.4.x
 
 ### Query string is now ignored when determining the current URL (#9)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,8 +8,8 @@ We accept PRs to improve this guide.
 
 `null` breadcrumb URLs are now supported for `diglactic/laravel-breadcrumbs` and `tabuna/breadcrumbs` collectors. 
 Previously, defining a `null` URL would've thrown an exception, so this is technically a backwards-compatible change.
-However, this changes the array shape of outputted breadcrumbs, and you may want to update frontend components to match.
-Here's an example TypeScript type to illustrate:
+However, because this changes the array shape of outputted breadcrumbs, you may want to update your frontend components
+to match. Here's an example TypeScript type to illustrate:
 
 ```diff
 type Breadcrumb {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,7 +4,7 @@ This document outlines breaking changes introduced in 0.x versions and major rel
 
 We accept PRs to improve this guide.
 
-## From 0.4.x to 0.5.x
+## From 0.5.x to TBD
 
 `null` breadcrumb URLs are now supported for `diglactic/laravel-breadcrumbs` and `tabuna/breadcrumbs` collectors. 
 Previously, defining a `null` URL would've thrown an exception, so this is technically a backwards-compatible change.

--- a/src/Collectors/AbstractBreadcrumbCollector.php
+++ b/src/Collectors/AbstractBreadcrumbCollector.php
@@ -16,7 +16,7 @@ abstract class AbstractBreadcrumbCollector implements BreadcrumbCollectorContrac
 
     protected function isCurrentUrl(Request $request, ?string $url): bool
     {
-        if (\is_null($url)) {
+        if (is_null($url)) {
             return false;
         }
 

--- a/src/Collectors/AbstractBreadcrumbCollector.php
+++ b/src/Collectors/AbstractBreadcrumbCollector.php
@@ -14,8 +14,12 @@ abstract class AbstractBreadcrumbCollector implements BreadcrumbCollectorContrac
         }
     }
 
-    protected function isCurrentUrl(Request $request, string $url): bool
+    protected function isCurrentUrl(Request $request, ?string $url): bool
     {
+        if (\is_null($url)) {
+            return false;
+        }
+
         if (config('inertia-breadcrumbs.ignore_query', true)) {
             return $request->url() === $url;
         }

--- a/tests/CollectorTest.php
+++ b/tests/CollectorTest.php
@@ -25,10 +25,13 @@ class CollectorTest extends TestCase
     public function it_creates_breadcrumb_collection_from_breadcrumbs()
     {
         $breadcrumbs = new BreadcrumbCollection([
-            new Breadcrumb('test', false),
+            new Breadcrumb('required', false),
+            new Breadcrumb('with-url', false, 'localhost'),
+            new Breadcrumb('with-null-url', false, null),
+            new Breadcrumb('with-data', false, 'localhost', ['foo' => 'bar']),
         ]);
 
-        $this->assertSame(1, $breadcrumbs->items()->count());
+        $this->assertSame(4, $breadcrumbs->items()->count());
     }
 
     #[Test]

--- a/tests/CollectorTest.php
+++ b/tests/CollectorTest.php
@@ -35,7 +35,7 @@ class CollectorTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_an_excpetion_with_invalid_breadcrumbs()
+    public function it_throws_an_exception_with_invalid_breadcrumbs()
     {
         $this->expectException(CannotCreateBreadcrumbException::class);
         new BreadcrumbCollection([

--- a/tests/DiglacticCollectorTest.php
+++ b/tests/DiglacticCollectorTest.php
@@ -84,15 +84,20 @@ class DiglacticCollectorTest extends TestCase
     #[Test]
     public function it_collects_diglactic_breadcrumbs()
     {
-        DiglacticBreadcrumbs::for('profile.edit', function (DiglacticTrail $trail) {
+        DiglacticBreadcrumbs::for('profile', function (DiglacticTrail $trail) {
             $trail->push('Profile', route('profile'));
+        });
+
+        DiglacticBreadcrumbs::for('profile.edit', function (DiglacticTrail $trail) {
+            $trail->parent('profile');
             $trail->push('Edit profile', route('profile.edit'));
+            $trail->push('Crumb without link');
         });
 
         $request = RequestBuilder::create('profile.edit');
         $crumbs = app(BreadcrumbCollectorContract::class)->forRequest($request);
 
-        $this->assertSame(2, $crumbs->items()->count());
+        $this->assertSame(3, $crumbs->items()->count());
         $this->assertSame([
             [
                 'title' => 'Profile',
@@ -102,6 +107,10 @@ class DiglacticCollectorTest extends TestCase
                 'title' => 'Edit profile',
                 'url' => route('profile.edit'),
                 'current' => true,
+            ],
+            [
+                'title' => 'Crumb without link',
+                'url' => null,
             ],
         ], $crumbs->toArray());
     }

--- a/tests/DiglacticCollectorTest.php
+++ b/tests/DiglacticCollectorTest.php
@@ -110,7 +110,6 @@ class DiglacticCollectorTest extends TestCase
             ],
             [
                 'title' => 'Crumb without link',
-                'url' => null,
             ],
         ], $crumbs->toArray());
     }

--- a/tests/TabunaCollectorTest.php
+++ b/tests/TabunaCollectorTest.php
@@ -91,7 +91,6 @@ class TabunaCollectorTest extends TestCase
             ],
             [
                 'title' => 'Crumb without link',
-                'url' => null,
             ],
         ], $crumbs->toArray());
     }

--- a/tests/TabunaCollectorTest.php
+++ b/tests/TabunaCollectorTest.php
@@ -65,15 +65,20 @@ class TabunaCollectorTest extends TestCase
     #[Test]
     public function it_collects_tabuna_breadcrumbs()
     {
-        TabunaBreadcrumbs::for('profile.edit', function (TabunaTrail $trail) {
+        TabunaBreadcrumbs::for('profile', function (TabunaTrail $trail) {
             $trail->push('Profile', route('profile'));
+        });
+
+        TabunaBreadcrumbs::for('profile.edit', function (TabunaTrail $trail) {
+            $trail->parent('profile');
             $trail->push('Edit profile', route('profile.edit'));
+            $trail->push('Crumb without link');
         });
 
         $request = RequestBuilder::create('profile.edit');
         $crumbs = app(BreadcrumbCollectorContract::class)->forRequest($request);
 
-        $this->assertSame(2, $crumbs->items()->count());
+        $this->assertSame(3, $crumbs->items()->count());
         $this->assertSame([
             [
                 'title' => 'Profile',
@@ -83,6 +88,10 @@ class TabunaCollectorTest extends TestCase
                 'title' => 'Edit profile',
                 'url' => route('profile.edit'),
                 'current' => true,
+            ],
+            [
+                'title' => 'Crumb without link',
+                'url' => null,
             ],
         ], $crumbs->toArray());
     }


### PR DESCRIPTION
Closes #14.

[From what I can tell](https://github.com/glhd/gretel?tab=readme-ov-file#parent-shorthand), `glhd/gretel` does not support `null` URLs, as breadcrumbs are tied to a route. `diglactic/laravel-breadcrumbs` and `tabuna/breadcrumbs` do, and I've added tests accordingly.

Other changes:
- Added a parent route in tests to ensure nothing weird happens with nesting
- Updated documentation to detail this change

Items of note:
1. **`CHANGELOG.md` entry must be finalized before merging.** I wasn't sure if this should be a patch or minor change, but felt like it was a significant enough change to warrant minor, and bumped docs from v0.4.0 to v0.5.0. That rationale is somewhat outlined in `UPGRADING.md`.
2. I did not squash my commits per the contribution guide, since they provide some insight into changes. Feel free to squash during merge or I can open a new PR.

Let me know if you would like me to make any changes. Thanks!