### PR TITLE
feat: add Laravel Boost AI guideline and skill

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,5 @@
+## Inertia Breadcrumbs
+
+This application uses `robertboes/inertia-breadcrumbs` to share breadcrumbs to the frontend as an Inertia shared prop (`breadcrumbs` by default).
+
+When defining breadcrumbs for a page, rendering a breadcrumb trail in an Inertia page component, or choosing/configuring the breadcrumb collector, use the `inertia-breadcrumbs` skill — it checks the project's actual setup before suggesting code, so you don't assume the wrong collector or frontend. If that skill isn't available, read the package's README or source under `vendor/robertboes/inertia-breadcrumbs` before writing code: the API is small but specific, so verify method and config names rather than guessing.

--- a/resources/boost/skills/inertia-breadcrumbs/SKILL.md
+++ b/resources/boost/skills/inertia-breadcrumbs/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: inertia-breadcrumbs
+description: Define, render, and configure breadcrumbs in a Laravel + Inertia app using the robertboes/inertia-breadcrumbs package. Use whenever adding or editing breadcrumbs for a page, building a breadcrumb trail or nav in an Inertia page component (Vue, React, or Svelte), choosing or configuring the breadcrumb collector (diglactic, tabuna, gretel, or the built-in closure collector), or customizing the share strategy, classifier, or serialization. Not for breadcrumbs outside an Inertia response.
+---
+
+# Inertia Breadcrumbs
+
+`robertboes/inertia-breadcrumbs` collects breadcrumbs from one of several sources and shares them to the frontend as an Inertia prop (default key: `breadcrumbs`). It does **not** define breadcrumbs itself for the third-party collectors — it adapts whatever the configured source produces into one consistent prop shape.
+
+The package supports four breadcrumb sources and any Inertia frontend, so the correct guidance depends entirely on how *this* project is set up. Detect that first; never assume a default.
+
+## Step 1 — Detect the setup (do not assume)
+
+Before writing or editing anything, determine:
+
+1. **Which collector is configured** — read `config/inertia-breadcrumbs.php` and look at the `collector` key. It will be one of:
+   - `ClosureBreadcrumbsCollector` — breadcrumbs defined in PHP via this package's own API (no extra dependency).
+   - `DiglacticBreadcrumbsCollector` — breadcrumbs defined with `diglactic/laravel-breadcrumbs` (usually `routes/breadcrumbs.php`).
+   - `TabunaBreadcrumbsCollector` — breadcrumbs defined with `tabuna/breadcrumbs`.
+   - `GretelBreadcrumbsCollector` — breadcrumbs defined with `glhd/gretel` (via route `->breadcrumb()` definitions).
+   - If the config file isn't published, the default is `DiglacticBreadcrumbsCollector`.
+2. **Which package is installed** — check `composer.json` (or use Boost's *Application Info* tool) to confirm the matching package is present. A mismatch (collector configured but package missing) throws `PackageNotInstalledException` on every web request.
+3. **The frontend framework** — Vue, React, or Svelte — from the Inertia setup, so rendering examples match the project.
+
+If the project has no breadcrumb setup yet and you're starting fresh, the built-in `ClosureBreadcrumbsCollector` needs no extra dependency; otherwise match the collector to the package already in use.
+
+## Step 2 — Do the task, then load the matching reference
+
+Read only the reference you need:
+
+- **Defining breadcrumbs** (adding/editing breadcrumbs for a page or route) → `references/defining-breadcrumbs.md`. This differs per collector — the closure collector uses this package's `for()` / `Breadcrumb::make()` API; the others are defined in their own package's syntax and merely collected here.
+- **Rendering breadcrumbs** (building the trail/nav in a page or layout component) → `references/rendering-breadcrumbs.md`. Covers the prop shape and Vue/React/Svelte examples.
+- **Configuring / extending** (share strategy, classifier, custom serialization, middleware key/group, query handling, the gretel caveat) → `references/configuration.md`.
+
+## The breadcrumb prop (quick reference)
+
+Whatever the collector, the shared prop is an array of objects in this shape — enough for most rendering without opening a reference:
+
+```json
+[
+  { "title": "Dashboard", "url": "https://app.test/dashboard" },
+  { "title": "Profile", "url": "https://app.test/dashboard/profile", "current": true },
+  { "title": "Breadcrumb without URL" }
+]
+```
+
+- `title` is always present. `url`, `current`, and `data` are omitted when not set (`null`/`false`/empty).
+- The whole prop is `null` when the current route has no breadcrumbs — guard on the value, not the key: `v-if="$page.props.breadcrumbs"`.
+- A custom serializer can change these keys (see `references/configuration.md`), so check for `serializeUsing` before assuming the default shape.
+
+## When unsure, read — don't invent
+
+This skill covers the common cases. If a detail isn't here, consult the source instead of guessing at method or config names:
+
+- Package README: <https://github.com/RobertBoes/inertia-breadcrumbs>
+- Config: `config/inertia-breadcrumbs.php`
+- Key classes in the installed package: `Breadcrumb` (the `make()` factory and accessors), the `Collectors\*` classes, `InertiaBreadcrumbs` (the `for()` / `serializeUsing()` API), and `Classifier\ClassifierContract`.
+
+Do not invent methods, config keys, or prop fields that you cannot find in those places.
+
+## Common mistakes to avoid
+
+- **Assuming the collector or frontend.** Always run Step 1 first; the project may use any of the four collectors and any Inertia frontend.
+- **Using `glhd/gretel` without disabling its own Inertia sharing.** Gretel auto-shares a `breadcrumbs` prop too; you must turn that off or you get double/competing data. See `references/configuration.md`.
+- **Defining closure-collector breadcrumbs when a third-party collector is configured** (or vice versa). The `for()` / `Breadcrumb::make()` API only applies to `ClosureBreadcrumbsCollector`.
+- **Assuming the default prop shape when a custom serializer is registered.**

--- a/resources/boost/skills/inertia-breadcrumbs/references/configuration.md
+++ b/resources/boost/skills/inertia-breadcrumbs/references/configuration.md
@@ -1,0 +1,102 @@
+# Configuring & extending
+
+All options live in `config/inertia-breadcrumbs.php` (publish with `php artisan vendor:publish --tag="inertia-breadcrumbs-config"`), except the serializer which is registered in code.
+
+## Config keys
+
+```php
+return [
+    'middleware' => [
+        'enabled' => true,   // set false to register the middleware yourself
+        'group'   => 'web',  // middleware group the breadcrumb sharing is added to
+        'key'     => 'breadcrumbs', // Inertia prop key
+    ],
+
+    'share' => \RobertBoes\InertiaBreadcrumbs\ShareStrategy::Default,
+
+    'collector' => \RobertBoes\InertiaBreadcrumbs\Collectors\DiglacticBreadcrumbsCollector::class,
+
+    'classifier' => \RobertBoes\InertiaBreadcrumbs\Classifier\AppendAllBreadcrumbs::class,
+
+    'ignore_query' => true, // ignore the query string when matching the current URL
+];
+```
+
+- Changing `middleware.key` changes the prop name on the frontend (default `breadcrumbs`).
+- `ignore_query = true` means `/users/1` and `/users/1?foo=bar` both match the breadcrumb for `/users/{id}`. Set it to `false` to treat query strings as distinct.
+
+## Share strategy
+
+Controls how the prop is shared with Inertia. Accepts the `ShareStrategy` enum or the equivalent string (`'default'`, `'always'`, `'deferred'`):
+
+- `ShareStrategy::Default` — standard shared prop; excluded from partial reloads unless explicitly requested.
+- `ShareStrategy::Always` — always included, even during partial reloads.
+- `ShareStrategy::Deferred` — excluded from the initial load, fetched automatically after the page renders.
+
+```php
+use RobertBoes\InertiaBreadcrumbs\ShareStrategy;
+
+'share' => ShareStrategy::Deferred, // or 'deferred'
+```
+
+## Classifier — decide when breadcrumbs are shared
+
+A classifier implements `RobertBoes\InertiaBreadcrumbs\Classifier\ClassifierContract` and decides whether a collection is shared. Built-in:
+
+- `AppendAllBreadcrumbs` (default) — always share.
+- `IgnoreSingleBreadcrumbs` — drop a collection that contains only one breadcrumb.
+
+Custom classifier:
+
+```php
+namespace App\Support;
+
+use Illuminate\Support\Str;
+use RobertBoes\InertiaBreadcrumbs\BreadcrumbCollection;
+use RobertBoes\InertiaBreadcrumbs\Classifier\ClassifierContract;
+
+class IgnoreAdminBreadcrumbs implements ClassifierContract
+{
+    public function shouldShareBreadcrumbs(BreadcrumbCollection $collection): bool
+    {
+        // URLs are absolute; compare against an absolute URL, and handle a null URL.
+        return ! Str::startsWith($collection->first()?->url() ?? '', url('/admin'));
+    }
+}
+```
+
+Then set `'classifier' => \App\Support\IgnoreAdminBreadcrumbs::class`.
+
+## Custom serialization
+
+To change the per-breadcrumb output shape, register a callback in a service provider's `boot()` (this overrides the default `title`/`url`/`current`/`data` keys):
+
+```php
+use RobertBoes\InertiaBreadcrumbs\Breadcrumb;
+use RobertBoes\InertiaBreadcrumbs\InertiaBreadcrumbs;
+
+app(InertiaBreadcrumbs::class)->serializeUsing(fn (Breadcrumb $breadcrumb) => [
+    'name'   => $breadcrumb->title(),
+    'href'   => $breadcrumb->url(),
+    'active' => $breadcrumb->current(),
+    'data'   => $breadcrumb->data(),
+]);
+```
+
+When a serializer is registered, the frontend prop uses *these* keys — update render components accordingly.
+
+## Using `glhd/gretel` — disable its own Inertia sharing
+
+Gretel auto-shares its own `breadcrumbs` prop when it detects Inertia, which collides with this package. Disable it in `config/gretel.php`:
+
+```php
+return [
+    'packages' => [
+        'inertiajs/inertia-laravel' => false,
+    ],
+];
+```
+
+## Registering the middleware yourself
+
+Set `middleware.enabled` to `false`, then add `\RobertBoes\InertiaBreadcrumbs\Middleware::class` to whichever group/stack you want. Useful when breadcrumbs should only be shared on specific route groups.

--- a/resources/boost/skills/inertia-breadcrumbs/references/defining-breadcrumbs.md
+++ b/resources/boost/skills/inertia-breadcrumbs/references/defining-breadcrumbs.md
@@ -1,0 +1,79 @@
+# Defining breadcrumbs
+
+How you define breadcrumbs depends on the configured collector (see Step 1 of the skill). This package only *collects and shares* — for the three third-party collectors, breadcrumbs are defined in that package's own syntax.
+
+## Closure collector (built-in, no extra dependency)
+
+When `config('inertia-breadcrumbs.collector')` is `ClosureBreadcrumbsCollector`, define breadcrumbs with this package's own API. Breadcrumbs are keyed by route name.
+
+`Breadcrumb::make()` signature:
+
+```php
+use RobertBoes\InertiaBreadcrumbs\Breadcrumb;
+
+Breadcrumb::make(
+    string $title,
+    ?string $url = null,   // optional; omit for a label-only crumb
+    ?array $data = null,    // optional extra payload (e.g. an icon)
+    bool $current = false,  // usually leave false — it's auto-detected by URL match
+): self;
+```
+
+### In a service provider (define once, by route name)
+
+```php
+use App\Models\User;
+use RobertBoes\InertiaBreadcrumbs\Breadcrumb;
+use RobertBoes\InertiaBreadcrumbs\InertiaBreadcrumbs;
+
+public function boot(): void
+{
+    $breadcrumbs = app(InertiaBreadcrumbs::class);
+
+    $breadcrumbs->for('users.index', fn () => [
+        Breadcrumb::make('Users', route('users.index')),
+    ]);
+
+    // Route parameters of the current route are passed to the closure, in order.
+    $breadcrumbs->for('users.show', fn (User $user) => [
+        Breadcrumb::make('Users', route('users.index')),
+        Breadcrumb::make($user->name, route('users.show', $user)),
+    ]);
+}
+```
+
+### In a controller (shorthand — route name inferred)
+
+Pass the closure as the first argument and the current route's name is inferred from the request:
+
+```php
+use App\Models\User;
+use RobertBoes\InertiaBreadcrumbs\Breadcrumb;
+use RobertBoes\InertiaBreadcrumbs\InertiaBreadcrumbs;
+
+public function show(User $user, InertiaBreadcrumbs $breadcrumbs)
+{
+    $breadcrumbs->for(fn (User $user) => [
+        Breadcrumb::make('Users', route('users.index')),
+        Breadcrumb::make($user->name, route('users.show', $user)),
+    ]);
+
+    return inertia('Users/Show', ['user' => $user]);
+}
+```
+
+Notes:
+- The shorthand only works on **named** routes (the name is read from the request). On unnamed routes the breadcrumbs are stored as pending and resolved for the current request only.
+- `current` is determined automatically by comparing each breadcrumb's URL with the current request URL. Set it explicitly only when needed: `Breadcrumb::make('Title', $url, current: true)`.
+- A label-only crumb (no link) omits the URL: `Breadcrumb::make('Current page')`.
+- Attach extra data for the frontend via the `data` argument: `Breadcrumb::make('Users', route('users.index'), ['icon' => 'users'])`.
+
+## Third-party collectors — define in their own syntax
+
+When one of these is configured, do **not** use `InertiaBreadcrumbs::for()`. Define breadcrumbs the way that package documents; this package collects whatever it produces for the current route.
+
+- **`DiglacticBreadcrumbsCollector`** → define with `diglactic/laravel-breadcrumbs`, typically in `routes/breadcrumbs.php` using `Breadcrumbs::for('name', fn (Trail $trail) => ...)`.
+- **`TabunaBreadcrumbsCollector`** → define with `tabuna/breadcrumbs` (e.g. `Breadcrumbs::for(...)` / route-attached definitions).
+- **`GretelBreadcrumbsCollector`** → define with `glhd/gretel` via route definitions, e.g. `->breadcrumb('Title')` chained on the route. Also requires disabling gretel's own Inertia sharing (see `configuration.md`).
+
+For the exact API of these third-party packages, consult their own documentation — do not guess. This package's responsibility ends at collecting and sharing what they generate.

--- a/resources/boost/skills/inertia-breadcrumbs/references/rendering-breadcrumbs.md
+++ b/resources/boost/skills/inertia-breadcrumbs/references/rendering-breadcrumbs.md
@@ -1,0 +1,96 @@
+# Rendering breadcrumbs
+
+Breadcrumbs are shared as the `breadcrumbs` Inertia prop (the key is configurable — see `configuration.md`). Render them in a page or layout component.
+
+## Prop shape
+
+An array of objects; `title` is always present, `url`/`current`/`data` are optional:
+
+```ts
+type Breadcrumb = {
+  title: string
+  url?: string      // omitted for label-only crumbs
+  current?: boolean // omitted when false
+  data?: Record<string, unknown> // omitted when none
+}
+```
+
+The whole prop is `null` when the current route has no breadcrumbs, so guard on the value (not the key's existence). If a custom serializer is registered the keys differ — confirm before relying on these names.
+
+## Vue 3
+
+```vue
+<template>
+  <nav v-if="$page.props.breadcrumbs" aria-label="Breadcrumb">
+    <ol>
+      <li v-for="crumb in $page.props.breadcrumbs" :key="crumb.title">
+        <a v-if="crumb.url" :href="crumb.url" :aria-current="crumb.current ? 'page' : undefined">
+          {{ crumb.title }}
+        </a>
+        <span v-else>{{ crumb.title }}</span>
+      </li>
+    </ol>
+  </nav>
+</template>
+```
+
+## React
+
+```tsx
+import { usePage } from '@inertiajs/react'
+
+export default function Breadcrumbs() {
+  const { breadcrumbs } = usePage().props
+
+  if (!breadcrumbs) return null
+
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol>
+        {breadcrumbs.map((crumb) => (
+          <li key={crumb.title}>
+            {crumb.url ? (
+              <a href={crumb.url} aria-current={crumb.current ? 'page' : undefined}>
+                {crumb.title}
+              </a>
+            ) : (
+              <span>{crumb.title}</span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  )
+}
+```
+
+## Svelte
+
+```svelte
+<script>
+  import { page } from '@inertiajs/svelte'
+  $: breadcrumbs = $page.props.breadcrumbs
+</script>
+
+{#if breadcrumbs}
+  <nav aria-label="Breadcrumb">
+    <ol>
+      {#each breadcrumbs as crumb (crumb.title)}
+        <li>
+          {#if crumb.url}
+            <a href={crumb.url} aria-current={crumb.current ? 'page' : undefined}>{crumb.title}</a>
+          {:else}
+            <span>{crumb.title}</span>
+          {/if}
+        </li>
+      {/each}
+    </ol>
+  </nav>
+{/if}
+```
+
+## Notes
+
+- Access any extra payload via `crumb.data` (e.g. `crumb.data?.icon`) when you defined breadcrumbs with a `data` argument.
+- Match the project's existing styling/markup conventions rather than imposing a fixed structure — these examples are minimal and unstyled on purpose.
+- If breadcrumbs aren't appearing: confirm the middleware is active and the current route actually has breadcrumbs defined for the configured collector; the prop is `null` (not an error) when there are none.

--- a/tests/BoostSkillTest.php
+++ b/tests/BoostSkillTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace RobertBoes\InertiaBreadcrumbs\Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RobertBoes\InertiaBreadcrumbs\Breadcrumb;
+use RobertBoes\InertiaBreadcrumbs\Classifier\AppendAllBreadcrumbs;
+use RobertBoes\InertiaBreadcrumbs\Classifier\ClassifierContract;
+use RobertBoes\InertiaBreadcrumbs\Classifier\IgnoreSingleBreadcrumbs;
+use RobertBoes\InertiaBreadcrumbs\Collectors\ClosureBreadcrumbsCollector;
+use RobertBoes\InertiaBreadcrumbs\Collectors\DiglacticBreadcrumbsCollector;
+use RobertBoes\InertiaBreadcrumbs\Collectors\GretelBreadcrumbsCollector;
+use RobertBoes\InertiaBreadcrumbs\Collectors\TabunaBreadcrumbsCollector;
+use RobertBoes\InertiaBreadcrumbs\InertiaBreadcrumbs;
+use RobertBoes\InertiaBreadcrumbs\ShareStrategy;
+
+/**
+ * Guards the Laravel Boost guideline + skill against drift. The skill teaches
+ * consumers how to use this package's API; if the API changes and the skill
+ * isn't updated, the skill starts handing out hallucination-shaped advice.
+ * These assertions tie every factual claim in the skill back to real code.
+ */
+class BoostSkillTest extends TestCase
+{
+    private function boostPath(string $relative): string
+    {
+        return __DIR__.'/../resources/boost/'.$relative;
+    }
+
+    #[Test]
+    public function it_ships_the_boost_files_in_the_documented_layout(): void
+    {
+        // The exact paths Boost scans for third-party guidelines and skills.
+        $this->assertFileExists($this->boostPath('guidelines/core.blade.php'));
+        $this->assertFileExists($this->boostPath('skills/inertia-breadcrumbs/SKILL.md'));
+        $this->assertFileExists($this->boostPath('skills/inertia-breadcrumbs/references/defining-breadcrumbs.md'));
+        $this->assertFileExists($this->boostPath('skills/inertia-breadcrumbs/references/rendering-breadcrumbs.md'));
+        $this->assertFileExists($this->boostPath('skills/inertia-breadcrumbs/references/configuration.md'));
+    }
+
+    #[Test]
+    public function the_skill_has_valid_frontmatter(): void
+    {
+        $contents = file_get_contents($this->boostPath('skills/inertia-breadcrumbs/SKILL.md'));
+
+        $this->assertStringStartsWith('---', $contents);
+        $this->assertMatchesRegularExpression('/^name:\s*inertia-breadcrumbs\s*$/m', $contents);
+        $this->assertMatchesRegularExpression('/^description:\s*\S+/m', $contents);
+    }
+
+    #[Test]
+    public function every_api_symbol_the_skill_teaches_exists(): void
+    {
+        $this->assertTrue(method_exists(Breadcrumb::class, 'make'));
+        $this->assertTrue(method_exists(InertiaBreadcrumbs::class, 'for'));
+        $this->assertTrue(method_exists(InertiaBreadcrumbs::class, 'serializeUsing'));
+        $this->assertTrue(method_exists(ClassifierContract::class, 'shouldShareBreadcrumbs'));
+
+        foreach ([
+            ClosureBreadcrumbsCollector::class,
+            DiglacticBreadcrumbsCollector::class,
+            GretelBreadcrumbsCollector::class,
+            TabunaBreadcrumbsCollector::class,
+            AppendAllBreadcrumbs::class,
+            IgnoreSingleBreadcrumbs::class,
+        ] as $class) {
+            $this->assertTrue(class_exists($class), "{$class} is referenced by the skill but no longer exists");
+        }
+
+        foreach (['default', 'always', 'deferred'] as $strategy) {
+            $this->assertNotNull(
+                ShareStrategy::tryFrom($strategy),
+                "ShareStrategy '{$strategy}' is referenced by the skill but no longer exists",
+            );
+        }
+    }
+
+    #[Test]
+    public function the_config_keys_the_skill_documents_exist(): void
+    {
+        $config = require __DIR__.'/../config/inertia-breadcrumbs.php';
+
+        $this->assertArrayHasKey('enabled', $config['middleware']);
+        $this->assertArrayHasKey('group', $config['middleware']);
+        $this->assertArrayHasKey('key', $config['middleware']);
+        $this->assertArrayHasKey('share', $config);
+        $this->assertArrayHasKey('collector', $config);
+        $this->assertArrayHasKey('classifier', $config);
+        $this->assertArrayHasKey('ignore_query', $config);
+
+        // The skill tells the frontend the default prop key is "breadcrumbs".
+        $this->assertSame('breadcrumbs', $config['middleware']['key']);
+    }
+
+    #[Test]
+    public function it_keeps_the_gretel_double_sharing_caveat(): void
+    {
+        // The single most important gotcha the skill encodes — losing it
+        // silently reintroduces the duplicate-breadcrumbs bug for gretel users.
+        $config = file_get_contents($this->boostPath('skills/inertia-breadcrumbs/references/configuration.md'));
+
+        $this->assertStringContainsString("'inertiajs/inertia-laravel' => false", $config);
+    }
+}


### PR DESCRIPTION
Adds a minimal always-on guideline pointer plus an on-demand inertia-breadcrumbs skill (SKILL.md + references) so AI agents using Laravel Boost get accurate, setup-aware help. Includes a drift-guard test tying the skill's API claims to the real code.